### PR TITLE
Fix Rails 4 unknown key :condition in has_many relation definition

### DIFF
--- a/lib/active_admin/gallery/active_record_extension.rb
+++ b/lib/active_admin/gallery/active_record_extension.rb
@@ -3,9 +3,9 @@ module ActiveAdmin::Gallery
 
     def has_image(name)
       has_one name,
+        -> { where(imageable_relation: name.to_s) },
         as: :imageable,
-        class_name: "ActiveAdmin::Gallery::Image",
-        -> { where(imageable_relation: name.to_s) }
+        class_name: "ActiveAdmin::Gallery::Image"
 
       define_method "#{name}=" do |image|
         super(image)
@@ -17,9 +17,9 @@ module ActiveAdmin::Gallery
 
     def has_many_images(name)
       has_many name,
+        -> { where(imageable_relation: name.to_s) },
         as: :imageable,
-        class_name: "ActiveAdmin::Gallery::Image",
-        -> { where(imageable_relation: name.to_s) }
+        class_name: "ActiveAdmin::Gallery::Image"
 
       define_method "#{name}=" do |images|
         super(images)


### PR DESCRIPTION
Hi, I'm using Rails 4.1.1 and it throws an exception:

```
Unknown key: :conditions. Valid keys are: :class_name, :class, :foreign_key, :validate, :autosave, :table_name, :before_add, :after_add, :before_remove, :after_remove, :extend, :primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache (ArgumentError)
```

Rails 4 has changed the way conditions to a scope or a relation, from :conditions to ->.
This quickfix solves the problem.
Maybe it'd be better to create another branch for rails 4+, because I don't know if this syntax is compatible with rails 3.
